### PR TITLE
feat: add efrup library functonality

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_TOKEN: '${{ secrets.GH_TOKEN }}'
         
       - name: Close Milestone
         run: |
-          ACCESS_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          ACCESS_TOKEN="${{ secrets.GH_TOKEN }}"
           MILESTONE_NUMBER=${{ github.event.inputs.milestoneId }}
           API_URL="https://api.github.com"
           
@@ -49,7 +49,7 @@ jobs:
       - name: Trigger Release Workflow
         uses: peter-evans/repository-dispatch@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ github.repository }}
           event-type: release
           client-payload: '{"milestone_number": "${{ github.event.inputs.milestoneId }}"}'

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 16.x
           registry-url: https://npm.pkg.github.com/
           # Defaults to the user or organization that owns the workflow file
-          scope: '@frmscoe'
+          scope: '@tazama-lf'
           
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,7 @@ name: Node.js CI
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NPM_SCOPE: "@frmscoe"
+  NPM_SCOPE: "@tazama-lf"
   NPM_REGISTRY: "https://npm.pkg.github.com/"
   NODE_ENV: 'test'
   STARTUP_TYPE: 'nats'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,7 +6,7 @@
 name: Node.js CI
 
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   NPM_SCOPE: "@tazama-lf"
   NPM_REGISTRY: "https://npm.pkg.github.com/"
   NODE_ENV: 'test'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: 20.x
           registry-url: https://npm.pkg.github.com/
-          scope: '@frmscoe'
+          scope: '@tazama-lf'
           
       # Install dependencies
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
 
       - uses: actions-ecosystem/action-release-label@v1
         id: release-label
         if: ${{ steps.get-merged-pull-request.outputs.title != null }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
 
       # Get the latest tag in the repository
       - uses: actions-ecosystem/action-get-latest-tag@v1
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_TOKEN: '${{ secrets.GH_TOKEN }}'
 
       # Run Tests
       - name: Run Tests
@@ -123,7 +123,7 @@ jobs:
         run: |
           # Retrieve the milestone ID from the workflow input
           MILESTONE_ID=${{ github.event.client_payload.milestone_number }}
-          MILESTONE_RESPONSE=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_ID}")
+          MILESTONE_RESPONSE=$(curl -s -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_ID}")
           MILESTONE_TITLE=$(echo "$MILESTONE_RESPONSE" | jq -r '.title')
           MILESTONE_DESCRIPTION=$(echo "$MILESTONE_RESPONSE" | jq -r '.description')
           MILESTONE_DATE=$(echo "$MILESTONE_RESPONSE" | jq -r '.due_on')
@@ -240,7 +240,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ steps.bump_version.outputs.new_version }}
           release_name: ${{ steps.bump_version.outputs.new_version }}
@@ -261,7 +261,7 @@ jobs:
           git commit -m "chore: Update CHANGELOG.md for $NEW_VERSION"
           git push origin HEAD:main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           STARTUP_TYPE: 'nats'
         
       # Update the VERSION file
@@ -275,5 +275,5 @@ jobs:
           git commit -m "chore: Update VERSION to $NEW_VERSION"
           git push origin HEAD:main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           STARTUP_TYPE: 'nats'

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-@frmscoe:registry=https://npm.pkg.github.com
+@tazama-lf:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GH_TOKEN}

--- a/__tests__/unit/logic.service.test.ts
+++ b/__tests__/unit/logic.service.test.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 /* eslint-disable */
-import { NetworkMap, Pacs002, RuleResult, Typology } from '@frmscoe/frms-coe-lib/lib/interfaces';
-import { TADPRequest } from '@frmscoe/frms-coe-lib/lib/interfaces/processor-files/TADPRequest';
+import { NetworkMap, Pacs002, RuleResult, Typology } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import { TADPRequest } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TADPRequest';
 import { configuration } from '../../src/config';
 import { databaseManager, dbInit, runServer, server } from '../../src/index';
-import { IRuleValue, ITypologyExpression } from '@frmscoe/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
+import { IRuleValue, ITypologyExpression } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
 import { handleTransaction } from '../../src/logic.service';
 import { evaluateTypologyExpression } from '../../src/utils/evaluateTExpression';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@cortex-js/compute-engine": "0.20.2",
-        "@frmscoe/frms-coe-lib": "4.1.0",
-        "@frmscoe/frms-coe-startup-lib": "2.2.0",
+        "@tazama-lf/frms-coe-lib": "4.2.0-alpha.6",
+        "@tazama-lf/frms-coe-startup-lib": "2.3.0-rc.0",
         "arangojs": "^8.8.1",
         "dotenv": "^16.4.5",
         "ioredis": "^5.4.1",
@@ -856,41 +856,6 @@
       "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "node_modules/@frmscoe/frms-coe-lib": {
-      "version": "4.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.1.0/801bd865896c57e4369b966be06dd296ef241026",
-      "integrity": "sha512-a54cpZMg/SiuFo2zNfseeGAfGOwXl7hQaDJaJeI7OBYTQGXR0y4oD31Mvy2dQ+t0w/tgM3wee4eaIsDSbVsKlg==",
-      "dependencies": {
-        "@elastic/ecs-pino-format": "^1.5.0",
-        "@frmscoe/frms-coe-lib": "file:",
-        "@grpc/grpc-js": "^1.11.1",
-        "@grpc/proto-loader": "^0.7.13",
-        "@types/uuid": "^9.0.8",
-        "arangojs": "^8.8.1",
-        "dotenv": "^16.4.5",
-        "elastic-apm-node": "^4.6.0",
-        "fast-json-stringify": "^5.16.0",
-        "ioredis": "^5.4.1",
-        "node-cache": "^5.1.2",
-        "pino": "^9.2.0",
-        "pino-elasticsearch": "^8.0.0",
-        "protobufjs": "^7.3.2",
-        "uuid": "^10.0.0"
-      }
-    },
-    "node_modules/@frmscoe/frms-coe-lib/node_modules/@frmscoe/frms-coe-lib": {
-      "resolved": "node_modules/@frmscoe/frms-coe-lib",
-      "link": true
-    },
-    "node_modules/@frmscoe/frms-coe-startup-lib": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-startup-lib/2.2.0/6f62c1f0a38b9dbf3908c371275ad3eb1c9c917b",
-      "integrity": "sha512-6eYSB+4DrbJA2AKD/9SsUAWLsFZ2Ut/xmGEsdwdM3f+oKPDdRyfPJ+AQaKS8JoLFdWuGANyiqamJ6aJ8hOE4HA==",
-      "dependencies": {
-        "@frmscoe/frms-coe-lib": "^4.0.0",
-        "nats": "^2.14.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -1802,6 +1767,36 @@
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@tazama-lf/frms-coe-lib": {
+      "version": "4.2.0-alpha.6",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/4.2.0-alpha.6/a8fde222dd1de7f2a520122963acf4d23efa0d6a",
+      "integrity": "sha512-kfyO8m4eXLuZcfE2wNpZI0kaLLF6tk7DhFNrZcsHFGkuvLjZgY5ZmWXV4T1SwqZLOMNGrqaibRTMQr2RlRKA5A==",
+      "dependencies": {
+        "@elastic/ecs-pino-format": "^1.5.0",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/uuid": "^9.0.8",
+        "arangojs": "^8.8.1",
+        "dotenv": "^16.4.5",
+        "elastic-apm-node": "^4.6.0",
+        "fast-json-stringify": "^5.16.0",
+        "ioredis": "^5.4.1",
+        "node-cache": "^5.1.2",
+        "pino": "^9.2.0",
+        "pino-elasticsearch": "^8.0.0",
+        "protobufjs": "^7.3.2",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/@tazama-lf/frms-coe-startup-lib": {
+      "version": "2.3.0-rc.0",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/2.3.0-rc.0/42b47a51fec2cee58a70480c47b5a04bffbe87bf",
+      "integrity": "sha512-ysj5tNLJPeRzQA/s8ICiebQAL+IqiDIG+V75B5dLIExIMAxr98IRz1S/26hAu7lDucYMGP9gdJ92DzWq6xqrrQ==",
+      "dependencies": {
+        "@tazama-lf/frms-coe-lib": "4.2.0-alpha.6",
+        "nats": "^2.14.0"
       }
     },
     "node_modules/@tokenizer/token": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "keywords": [
     "mojaloop",
-    "actio",
+    "tazama",
     "frm"
   ],
   "contributors": [
@@ -36,8 +36,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cortex-js/compute-engine": "0.20.2",
-    "@frmscoe/frms-coe-lib": "4.1.0",
-    "@frmscoe/frms-coe-startup-lib": "2.2.0",
+    "@tazama-lf/frms-coe-lib": "4.2.0-alpha.6",
+    "@tazama-lf/frms-coe-startup-lib": "2.3.0-rc.0",
     "arangojs": "^8.8.1",
     "dotenv": "^16.4.5",
     "ioredis": "^5.4.1",

--- a/src/apm.ts
+++ b/src/apm.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { Apm } from '@frmscoe/frms-coe-lib/lib/services/apm';
+import { Apm } from '@tazama-lf/frms-coe-lib/lib/services/apm';
 import { configuration } from './config';
 /*
  * Initialize the APM Logging

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 
-import { type RedisConfig } from '@frmscoe/frms-coe-lib/lib/interfaces';
+import { type RedisConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 
 // Load .env file into process.env if it exists. This is convenient for running locally.
 dotenv.config({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import './apm';
 import { ComputeEngine } from '@cortex-js/compute-engine';
-import { LoggerService, type DatabaseManagerInstance } from '@frmscoe/frms-coe-lib';
-import { StartupFactory, type IStartupService } from '@frmscoe/frms-coe-startup-lib';
-import { getRoutesFromNetworkMap } from '@frmscoe/frms-coe-lib/lib/helpers/networkMapIdentifiers';
+import { LoggerService, type DatabaseManagerInstance } from '@tazama-lf/frms-coe-lib';
+import { StartupFactory, type IStartupService } from '@tazama-lf/frms-coe-startup-lib';
+import { getRoutesFromNetworkMap } from '@tazama-lf/frms-coe-lib/lib/helpers/networkMapIdentifiers';
 import cluster from 'cluster';
 import os from 'os';
 import { configuration } from './config';

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import apm from './apm';
-import { CalculateDuration } from '@frmscoe/frms-coe-lib/lib/helpers/calculatePrcg';
-import { type NetworkMap, type RuleResult } from '@frmscoe/frms-coe-lib/lib/interfaces';
-import { type MetaData } from '@frmscoe/frms-coe-lib/lib/interfaces/metaData';
-import { type TADPRequest } from '@frmscoe/frms-coe-lib/lib/interfaces/processor-files/TADPRequest';
-import { type TypologyResult } from '@frmscoe/frms-coe-lib/lib/interfaces/processor-files/TypologyResult';
+import { CalculateDuration } from '@tazama-lf/frms-coe-lib/lib/helpers/calculatePrcg';
+import { type NetworkMap, type RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import { type MetaData } from '@tazama-lf/frms-coe-lib/lib/interfaces/metaData';
+import { type TADPRequest } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TADPRequest';
+import { type TypologyResult } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyResult';
 import { databaseManager, loggerService, server } from '.';
 import { configuration } from './config';
-import { type ITypologyExpression } from '@frmscoe/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
+import { type ITypologyExpression } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
 import { evaluateTypologyExpression } from './utils/evaluateTExpression';
 
 const saveToRedisGetAll = async (transactionId: string, ruleResult: RuleResult): Promise<RuleResult[] | undefined> => {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { CreateDatabaseManager } from '@frmscoe/frms-coe-lib';
+import { CreateDatabaseManager } from '@tazama-lf/frms-coe-lib';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-extraneous-class */
 export class Singleton {

--- a/src/utils/evaluateTExpression.ts
+++ b/src/utils/evaluateTExpression.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type SemiBoxedExpression } from '@cortex-js/compute-engine';
-import { type RuleResult } from '@frmscoe/frms-coe-lib/lib/interfaces';
+import { type RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { computeEngine, loggerService } from '..';
-import { type ExpressionMathJSON, type IRuleValue } from '@frmscoe/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
+import { type ExpressionMathJSON, type IRuleValue } from '@tazama-lf/frms-coe-lib/lib/interfaces/processor-files/TypologyConfig';
 
 export const evaluateTypologyExpression = (
   ruleValues: IRuleValue[],


### PR DESCRIPTION
## What did we change?
- Upgrade library to include parsing/serialization of efrup workflow properties
- Migrate to new org scope (library + imports)

## Why are we doing this?
To be able to forward flowprocessor workflow to tadp
   - Related: tazama-lf/transaction-aggregation-decisioning-processor#199

## How was it tested?
- [x] Locally
- [x] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [ ] Unit tests passing and Documentation done
